### PR TITLE
remove aica frame skipping, unnecessary being that we're timing based…

### DIFF
--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -214,13 +214,13 @@ static void *emu_core_thread(void *data) {
   int64_t next_pump_time = 0;
 
   while (emu->running) {
-    current_time = time_nanoseconds();
-
     while (audio_buffer_low(audio)) {
       dc_tick(emu->dc, MACHINE_STEP);
     }
 
     /* audio events are just for device connections, check infrequently */
+    current_time = time_nanoseconds();
+
     if (current_time > next_pump_time) {
       audio_pump_events(audio);
       next_pump_time = current_time + NS_PER_SEC;

--- a/src/hw/aica/aica.c
+++ b/src/hw/aica/aica.c
@@ -22,7 +22,6 @@ DEFINE_AGGREGATE_COUNTER(aica_samples);
 #define LOG_AICA(...)
 #endif
 
-#define AICA_SAMPLE_FREQ 44100
 #define AICA_SAMPLE_BATCH 10
 #define AICA_NUM_CHANNELS 64
 
@@ -389,16 +388,6 @@ static void aica_write_frames(struct aica *aica, const void *frames,
   if (aica->recording) {
     fwrite(frames, 1, size, aica->recording);
   }
-}
-
-int aica_skip_frames(struct aica *aica, int num_frames) {
-  int available = ringbuf_available(aica->frames);
-  int size = MIN(available, num_frames * 4);
-  CHECK_EQ(size % 4, 0);
-
-  ringbuf_advance_read_ptr(aica->frames, size);
-
-  return size / 4;
 }
 
 int aica_read_frames(struct aica *aica, void *frames, int num_frames) {

--- a/src/hw/aica/aica.h
+++ b/src/hw/aica/aica.h
@@ -7,6 +7,8 @@
 struct aica;
 struct dreamcast;
 
+#define AICA_SAMPLE_FREQ 44100
+
 AM_DECLARE(aica_reg_map);
 AM_DECLARE(aica_data_map);
 
@@ -14,7 +16,6 @@ struct aica *aica_create(struct dreamcast *dc);
 void aica_destroy(struct aica *aica);
 
 int aica_available_frames(struct aica *aica);
-int aica_skip_frames(struct aica *aica, int num_frames);
 int aica_read_frames(struct aica *aica, void *buffer, int num_frames);
 
 #endif

--- a/src/hw/pvr/ta.c
+++ b/src/hw/pvr/ta.c
@@ -733,11 +733,9 @@ static void ta_start_render(struct ta *ta, struct tile_ctx *ctx) {
   int num_polys = 0;
   ta_register_texture_sources(ta, ctx, &num_polys);
 
-  /* supposedly, the dreamcast can push around ~3 million polygons per second
-     through the TA / PVR. with that in mind, a very poor estimate can be made
-     for how long the TA would take to render a frame based on the number of
-     polys pushed: 1,000,000,000 / 3,000,000 = 333 nanoseconds per polygon */
-  int64_t ns = num_polys * INT64_C(333);
+  /* give each frame 10 ms to finish rendering
+     TODO figure out a heuristic involving the number of polygons rendered */
+  int64_t ns = INT64_C(10000000);
   scheduler_start_timer(ta->scheduler, &ta_render_timer, ta, ns);
 
   if (ta->trace_writer) {


### PR DESCRIPTION
… on the aica buffer state, not the host's buffer

give ta a fixed amount of time to render each frame until a better heuristic is figured out